### PR TITLE
Remove carriage return EOL on export GFF

### DIFF
--- a/src/fn_export_gff.R
+++ b/src/fn_export_gff.R
@@ -51,7 +51,7 @@ export.gff = function(temp.folder = "",
   
   print("wrtiting repeats")
   options(scipen=10)
-  write.table(x = gff_format, file = paste(temp.folder, "/TRASH_", assemblyName, ".gff", sep = ""), quote = FALSE, sep = "\t", eol = "\r", row.names = FALSE, col.names = FALSE)
+  write.table(x = gff_format, file = paste(temp.folder, "/TRASH_", assemblyName, ".gff", sep = ""), quote = FALSE, sep = "\t", row.names = FALSE, col.names = FALSE)
   options(scipen=0)
   
 }


### PR DESCRIPTION
Carriage return EOL is incompatible with downstream software that parses GFF, e.g., IGV - unless there was a reason I'm missing for this?

Cheers